### PR TITLE
Path fix and single instance

### DIFF
--- a/go_conemu/__init__.py
+++ b/go_conemu/__init__.py
@@ -1,4 +1,5 @@
 from fman import DirectoryPaneCommand, show_alert
+from fman.url import as_human_readable
 import subprocess
 
 class GoConemu(DirectoryPaneCommand):

--- a/go_conemu/__init__.py
+++ b/go_conemu/__init__.py
@@ -4,5 +4,5 @@ import subprocess
 class GoConemu(DirectoryPaneCommand):
 	def __call__(self):
 		conemu_path = "C:\\Program Files\\ConEmu\\ConEmu64.exe"
-		current_path = self.pane.get_path()[7:]
-		subprocess.call(conemu_path + " -Dir " + '"' + current_path + '"')
+		current_path = self.pane.get_path()
+		subprocess.call(f'"{conemu_path}" -Single -Dir "{as_human_readable(current_path)}"')


### PR DESCRIPTION
Fix path issue found with self.pane.get_path(). Make ConEmu launch in single instasnce (creates a new tab instead of a brand new instance).

From experimenting with fman, found your plug in but was having issues getting the script to work. Poked around and found an "as_human_readable" package from fman, which converted the "self.pane.get_path()" from the "file://c:/Program Files/Google/" to "C:\Program Files\Google". 

The -Single flag just opens your current running ConEmu instance and creates a new tab, instead of a brand new instance every time. It will also launch ConEmu if it is not running.